### PR TITLE
refactor: remove profile and email scopes from OAuth flow

### DIFF
--- a/lib/auth/ensureAuth.ts
+++ b/lib/auth/ensureAuth.ts
@@ -22,7 +22,7 @@ const deviceCodeAuth = new DeviceCodeAuth(authConfig);
 async function deviceCodeFlow(): Promise<string> {
   logger.info("Starting device code flow");
 
-  const scope = "openid profile email offline_access user:content:manage";
+  const scope = "openid offline_access user:content:manage";
   const deviceCodeResult = await deviceCodeAuth.initiate(scope);
 
   if (!deviceCodeResult.success || !deviceCodeResult.deviceCode) {


### PR DESCRIPTION
Removes the `profile` and `email` scopes from the OAuth device code flow, leaving only the necessary scopes:

- `openid` - required for authentication
- `offline_access` - required for refresh tokens
- `user:content:manage` - required for Yoto content API access

This reduces the permission footprint of the tool.