### PR TITLE
fix: preserve .exe extension in Windows build zip

### DIFF
--- a/scripts/build-zip.js
+++ b/scripts/build-zip.js
@@ -17,16 +17,14 @@ if (!fs.existsSync("artifacts")) {
 }
 
 // Helper function to create zip for a specific binary
-function createZipForBinary(binaryName, zipName, tempDir) {
-  // Create temp directory
+function createZipForBinary(binaryName, zipName, tempDir, outputName) {
   if (fs.existsSync(tempDir)) {
     fs.rmSync(tempDir, { recursive: true });
   }
   fs.mkdirSync(tempDir);
 
   try {
-    // Copy the binary and rename it
-    fs.copyFileSync(binaryName, path.join(tempDir, "twine2yoto"));
+    fs.copyFileSync(binaryName, path.join(tempDir, outputName));
 
     // Copy other files
     const filesToInclude = ["docs.md", "example.env"];
@@ -79,6 +77,7 @@ try {
         arm64Binary,
         `twine2yoto-macos-arm64-${version}.zip`,
         "artifacts/temp-arm64",
+        "twine2yoto",
       );
     }
 
@@ -87,6 +86,7 @@ try {
         x64Binary,
         `twine2yoto-macos-x64-${version}.zip`,
         "artifacts/temp-x64",
+        "twine2yoto",
       );
     }
 
@@ -101,6 +101,7 @@ try {
         binaryName,
         `twine2yoto-${platform}-${version}.zip`,
         "artifacts/temp-win",
+        "twine2yoto.exe",
       );
     } else {
       console.warn(`Warning: ${binaryName} not found, skipping...`);


### PR DESCRIPTION
## Summary
- Fixes #2 — Windows binary inside the release zip was missing the `.exe` extension
- Added an `outputName` parameter to `createZipForBinary` so Windows builds retain `twine2yoto.exe` while macOS builds remain unchanged

## Test plan
- [x] All existing tests pass
- [x] Lint and typecheck pass
- [ ] Verify next Windows release zip contains `twine2yoto.exe`


Made with [Cursor](https://cursor.com)