### PR TITLE
feat: migrate to bulk MYO endpoint with dedicated scope

### DIFF
--- a/lib/apis/api.yoto.ts
+++ b/lib/apis/api.yoto.ts
@@ -44,7 +44,7 @@ export async function uploadFile(url: string, fileContent: Buffer) {
 }
 
 export async function updateCard(access_token: string, card: YotoJSON) {
-  const url = `${YOTO_API_URL}/content`;
+  const url = `${YOTO_API_URL}/content/bulk`;
 
   const response = await client.post(url, card, {
     headers: { Authorization: `Bearer ${access_token}` },

--- a/lib/auth/ensureAuth.ts
+++ b/lib/auth/ensureAuth.ts
@@ -22,7 +22,7 @@ const deviceCodeAuth = new DeviceCodeAuth(authConfig);
 async function deviceCodeFlow(): Promise<string> {
   logger.info("Starting device code flow");
 
-  const scope = "openid offline_access user:content:manage";
+  const scope = "openid offline_access user:content:manage-bulk";
   const deviceCodeResult = await deviceCodeAuth.initiate(scope);
 
   if (!deviceCodeResult.success || !deviceCodeResult.deviceCode) {


### PR DESCRIPTION
## Summary
- Switches `updateCard()` from `POST /content` → `POST /content/bulk`
- Updates requested OAuth scope from `user:content:manage` → `user:content:manage-bulk`

## Context
Part of [ADR-23](https://www.notion.so/32c7f477332681f8aea8f44195fd6545) — splitting the `upsertCard` handler into dedicated endpoints. The bulk endpoint grants elevated MYO access (no 100-track limit) without requiring `admin:content:manage`.

## ⚠️ Note for existing users
Cached tokens at `~/.twine2yoto/tokens.json` will not include the new scope. Users will need to re-authenticate (run `twine-to-yoto login` or use `--clearAuth`).

## Test plan
- [ ] Authenticate fresh and verify `user:content:manage-bulk` scope is present in the token
- [ ] Upload a card with >100 tracks and confirm it succeeds against the bulk endpoint
- [ ] Confirm `POST /content` (standard endpoint) is no longer called

🤖 Generated with [Claude Code](https://claude.com/claude-code)